### PR TITLE
Provide access to Project files during Container build

### DIFF
--- a/containerized/__main__.py
+++ b/containerized/__main__.py
@@ -73,6 +73,7 @@ def build_podman_image(containerfile_path, context_directory, image_name):
     build_command = [
         "podman", "build", 
         "-f", containerfile_path,  # Path to Containerfile
+	"--volume", f"{context_directory}:/mnt",   # Mount project folder
         "-t", image_name,       # Tag for the image
         context_directory       # Context directory
     ]


### PR DESCRIPTION
Some frameworks (e.g. `poetry`) modify files in the project root during dependency installation. To allow them to do this while keeping the project files in sync with what these tools write, we mount the project folder to `/mnt` during build as we do during runtime. 